### PR TITLE
Add Squarespace export script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,4 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -10,15 +10,19 @@ ss2wp is a Python script that helps migrate blog posts from Squarespace to WordP
 
 ## Usage
 
-The script will be invoked from the command line and requires Python 3. Run it with the target post URL:
+The script requires Python 3 and `requests` plus `beautifulsoup4` packages. Install the dependencies and run the script with the target post URL:
 
 ```bash
+pip install requests beautifulsoup4
 python ss2wp.py <squarespace-post-url>
 ```
 
-The downloaded images will be saved in an `images` folder in the current directory. The resulting HTML will be printed to standard output for easy copying, or optionally written to a file.
+The downloaded images will be saved in an `images` folder in the current directory. The resulting HTML will be printed to standard output for easy copying, or optionally written to a file using `-o`:
+
+```bash
+python ss2wp.py <url> -o output.html
+```
 
 ## Status
 
-This repository currently contains the project description. Implementation of the script will come next.
-
+The script is functional and ready to be used for simple migrations.

--- a/ss2wp.py
+++ b/ss2wp.py
@@ -1,0 +1,113 @@
+import argparse
+import os
+import re
+import sys
+import uuid
+from pathlib import Path
+
+import requests
+from bs4 import BeautifulSoup
+
+
+HEADERS = {
+    "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0 Safari/537.36"
+}
+
+
+def fetch_page(url: str) -> str:
+    """Retrieve the HTML content for the given URL."""
+    resp = requests.get(url, headers=HEADERS, timeout=30)
+    resp.raise_for_status()
+    return resp.text
+
+
+def parse_post(html: str) -> tuple[str, BeautifulSoup]:
+    """Extract the title and article body soup from the HTML."""
+    soup = BeautifulSoup(html, "html.parser")
+
+    # Attempt to determine the title
+    title = None
+    og_title = soup.find("meta", property="og:title")
+    if og_title and og_title.get("content"):
+        title = og_title["content"].strip()
+    if not title:
+        title_tag = soup.find(re.compile("^h[1-2]$"))
+        if title_tag and title_tag.text.strip():
+            title = title_tag.text.strip()
+    if not title:
+        title = "Untitled Post"
+
+    # Article content
+    article = soup.find("article")
+    if not article:
+        article = soup.find("main")
+    if not article:
+        # Fallback to body
+        article = soup.find("body")
+
+    return title, article
+
+
+def ensure_images_dir(path: Path) -> Path:
+    images_dir = path / "images"
+    images_dir.mkdir(exist_ok=True)
+    return images_dir
+
+
+def download_image(url: str, images_dir: Path) -> str:
+    """Download an image and return its local filename."""
+    resp = requests.get(url, headers=HEADERS, timeout=30)
+    resp.raise_for_status()
+
+    # Generate unique filename from uuid and extension
+    ext = os.path.splitext(url.split("?")[0])[1] or ".jpg"
+    filename = f"{uuid.uuid4().hex}{ext}"
+    filepath = images_dir / filename
+    with open(filepath, "wb") as f:
+        f.write(resp.content)
+    return filename
+
+
+def process_images(soup: BeautifulSoup, images_dir: Path) -> None:
+    for img in soup.find_all("img"):
+        src = img.get("src")
+        if not src:
+            continue
+        try:
+            filename = download_image(src, images_dir)
+            img["src"] = f"images/{filename}"
+        except Exception as exc:
+            print(f"Failed to download {src}: {exc}", file=sys.stderr)
+
+
+def build_html(title: str, content: BeautifulSoup) -> str:
+    html_parts = [f"<h1>{title}</h1>"]
+    for element in content.find_all(["p", "img", "ul", "ol", "pre", "blockquote"]):
+        html_parts.append(str(element))
+    return "\n".join(html_parts)
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Convert Squarespace post to WordPress HTML")
+    parser.add_argument("url", help="URL of the Squarespace post")
+    parser.add_argument("-o", "--output", help="Optional output file")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    html = fetch_page(args.url)
+    title, content = parse_post(html)
+    images_dir = ensure_images_dir(Path.cwd())
+    process_images(content, images_dir)
+    output_html = build_html(title, content)
+
+    if args.output:
+        Path(args.output).write_text(output_html, encoding="utf-8")
+    else:
+        print(output_html)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary
- implement `ss2wp.py` for converting Squarespace posts to WordPress-ready HTML
- update README with dependency and usage info

## Testing
- `python3 -m py_compile ss2wp.py`
- `python3 ss2wp.py --help`
- ⚠️ `python3 ss2wp.py https://example.com` (failed to fetch due to network access restrictions)


------
https://chatgpt.com/codex/tasks/task_e_687a791822c4832d82b1b116af694eb3