### PR TITLE
Fix heading tags removed

### DIFF
--- a/ss2wp.py
+++ b/ss2wp.py
@@ -128,7 +128,7 @@ def build_html(title: str, content: BeautifulSoup) -> str:
     html_parts = [f"<h1>{title}</h1>"]
 
     allowed_tags = ["p", "ul", "ol", "pre", "blockquote"]
-    allowed_tags.extend(f"h{i}" for i in range(2, 7))
+    allowed_tags.extend(f"h{i}" for i in range(1, 7))
 
     for element in content.find_all(allowed_tags):
         html_parts.append(str(element))

--- a/ss2wp.py
+++ b/ss2wp.py
@@ -124,9 +124,15 @@ def strip_paragraph_classes(soup: BeautifulSoup) -> None:
 
 
 def build_html(title: str, content: BeautifulSoup) -> str:
+    """Return minimal HTML for the post body including headings."""
     html_parts = [f"<h1>{title}</h1>"]
-    for element in content.find_all(["p", "ul", "ol", "pre", "blockquote"]):
+
+    allowed_tags = ["p", "ul", "ol", "pre", "blockquote"]
+    allowed_tags.extend(f"h{i}" for i in range(2, 7))
+
+    for element in content.find_all(allowed_tags):
         html_parts.append(str(element))
+
     return "\n".join(html_parts)
 
 


### PR DESCRIPTION
## Summary
- keep heading tags `<h2>`-`<h6>` in the generated HTML

## Testing
- `python -m py_compile ss2wp.py`


------
https://chatgpt.com/codex/tasks/task_e_687c2d93ab3c832d972e515e31c0fde7