### PR TITLE
Strip 'read more' links from gallery descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ ss2wp is a Python script that helps migrate blog posts from Squarespace to WordP
 - **Download post images** into a local directory with filenames derived from the post title
 - **Replace images with placeholders** using `<p>[[[ IMAGE ]]]</p>` in the output
 - **Append gallery description** below the post content when available
+- **Remove trailing "Read More" links** from gallery descriptions
 
 ## Usage
 

--- a/ss2wp.py
+++ b/ss2wp.py
@@ -109,7 +109,11 @@ def extract_gallery_images(html: str, gallery_url: str) -> tuple[list[str], str]
     desc_div = project.find("div", class_="project-description")
     description = ""
     if desc_div:
-        description = desc_div.get_text(strip=True)
+        for a in desc_div.find_all("a"):
+            if a.get_text(strip=True).lower() == "read more":
+                a.decompose()
+        description = desc_div.get_text(" ", strip=True)
+        description = re.sub(r"\s*read\s*more\s*$", "", description, flags=re.I)
 
     images: list[str] = []
     for img in image_list.find_all("img"):


### PR DESCRIPTION
## Summary
- exclude trailing `Read More` links from gallery descriptions
- document the behavior in the README

## Testing
- `python -m py_compile ss2wp.py`
- `python ss2wp.py --help`

------
https://chatgpt.com/codex/tasks/task_e_687ebb6d86fc832d8dfc94622afcb03b