### PR TITLE
Update output logic for headings and images

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ ss2wp is a Python script that helps migrate blog posts from Squarespace to WordP
 - **Generate clean HTML** that preserves basic formatting and is ready to paste into WordPress
 - **Download post images** into a local directory with filenames derived from the post title
 - **Replace images with placeholders** using `<p>[[[ IMAGE ]]]</p>` in the output
+- **Omit the first image placeholder** so you can place the lead image manually
+- **Exclude original `<h1>` headings** to prevent duplicate titles in WordPress
 - **Append gallery description** below the post content when available
 - **Remove trailing "Read More" links** from gallery descriptions
 

--- a/ss2wp.py
+++ b/ss2wp.py
@@ -185,7 +185,9 @@ def build_html(
     html_parts = [f"<h1>{title}</h1>"]
 
     allowed_tags = ["p", "ul", "ol", "pre", "blockquote"]
-    allowed_tags.extend(f"h{i}" for i in range(1, 7))
+    # Exclude ``h1`` tags from the body to avoid duplicating the page's
+    # main heading in the generated output.
+    allowed_tags.extend(f"h{i}" for i in range(2, 7))
 
     for element in content.find_all(allowed_tags):
         html_parts.append(str(element))
@@ -233,6 +235,9 @@ def main(argv: list[str]) -> int:
     strip_paragraph_classes(content)
 
     output_html = build_html(title, content, gallery_description or None)
+    # Drop the first image placeholder if one exists to mimic Squarespace's
+    # lead image handling.
+    output_html = re.sub(r"\n?<p>\[\[\[ IMAGE \]\]\]</p>\n?", "", output_html, count=1)
 
     output_file = post_dir / f"{post_name}.html"
     output_file.write_text(output_html, encoding="utf-8")


### PR DESCRIPTION
## Summary
- avoid copying `<h1>` tags from the source article
- remove the first `[[[ IMAGE ]]]` placeholder from the generated HTML
- document the new behavior in the README

## Testing
- `python -m py_compile ss2wp.py`
- `python ss2wp.py --help`


------
https://chatgpt.com/codex/tasks/task_e_687ee372664c832db9d2ba60e010bc57