### PR TITLE
Handle "Read More..." in gallery description cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ ss2wp is a Python script that helps migrate blog posts from Squarespace to WordP
 - **Omit the first image placeholder** so you can place the lead image manually
 - **Exclude original `<h1>` headings** to prevent duplicate titles in WordPress
 - **Append gallery description** below the post content when available
-- **Remove trailing "Read More" links** from gallery descriptions
+- **Remove trailing "Read More" links** (including "Read More...") from gallery descriptions
 
 ## Usage
 

--- a/ss2wp.py
+++ b/ss2wp.py
@@ -110,10 +110,13 @@ def extract_gallery_images(html: str, gallery_url: str) -> tuple[list[str], str]
     description = ""
     if desc_div:
         for a in desc_div.find_all("a"):
-            if a.get_text(strip=True).lower() == "read more":
+            text = a.get_text(strip=True)
+            if re.match(r"read\s*more(?:\.{3}|…)?$", text, flags=re.I):
                 a.decompose()
         description = desc_div.get_text(" ", strip=True)
-        description = re.sub(r"\s*read\s*more\s*$", "", description, flags=re.I)
+        description = re.sub(
+            r"\s*read\s*more(?:\.{3}|…)?\s*$", "", description, flags=re.I
+        )
 
     images: list[str] = []
     for img in image_list.find_all("img"):


### PR DESCRIPTION
## Summary
- handle trailing `Read More...` text when stripping gallery descriptions
- document that `Read More...` links are also removed

## Testing
- `python -m py_compile ss2wp.py`
- `python ss2wp.py --help | head`

------
https://chatgpt.com/codex/tasks/task_e_687eeb9b2858832d899c7b10c83eb456